### PR TITLE
Fix setup toolchain in release

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -23,6 +23,10 @@ jobs:
         run: long="${{ github.ref }}"; version=${long#"refs/tags/v"}; echo "version=${version}" >> $GITHUB_ENV
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: 11
       - uses: gradle/gradle-build-action@v2          
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
`macOS-latest` still uses JVM 8 by default...